### PR TITLE
added standard js and fix some formating

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm](https://img.shields.io/npm/v/zhihu-api.svg)](https://www.npmjs.com/package/zhihu-api)
 [![npm](https://img.shields.io/npm/dt/zhihu-api.svg)](https://www.npmjs.com/package/zhihu-api)
 [![Travis](https://img.shields.io/travis/syaning/zhihu-api.svg)](https://travis-ci.org/syaning/zhihu-api)
+[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 **UNOFFICIAL** API for [zhihu](https://www.zhihu.com).
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,10 @@ const Org = require('./lib/api/org')
 const Topic = require('./lib/api/topic')
 const Question = require('./lib/api/question')
 const Answer = require('./lib/api/answer')
-const package = require('./package')
 
 var _request = new Request()
 
-function cookie(val) {
+function cookie (val) {
   if (!arguments.length) {
     return _request.headers['Cookie']
   } else {
@@ -16,19 +15,28 @@ function cookie(val) {
   }
 }
 
-User.prototype.__proto__ = _request
-Org.prototype.__proto__ = _request
-Topic.prototype.__proto__ = _request
-Question.prototype.__proto__ = _request
-Answer.prototype.__proto__ = _request
+function proxy (val) {
+  if (!arguments.length) {
+    return _request.proxy
+  } else {
+    _request.setProxy(val)
+  }
+}
+
+Object.setPrototypeOf(User.prototype, _request)
+Object.setPrototypeOf(Org.prototype, _request)
+Object.setPrototypeOf(Topic.prototype, _request)
+Object.setPrototypeOf(Question.prototype, _request)
+Object.setPrototypeOf(Answer.prototype, _request)
 
 module.exports = {
   _request,
   cookie,
+  proxy,
   user: User,
   org: Org,
   topic: Topic,
   question: Question,
   answer: Answer,
-  version: package.version
+  version: require('./package').version
 }

--- a/lib/api/account.js
+++ b/lib/api/account.js
@@ -6,7 +6,7 @@ module.exports = {
    *
    * @public
    */
-  profile() {
+  profile () {
     var url = `/node/MemberProfileCardV2`
     var params = {
       params: JSON.stringify({
@@ -24,7 +24,7 @@ module.exports = {
    * @param {number} offset
    * @public
    */
-  followers(offset = 0) {
+  followers (offset = 0) {
     var url = '/node/ProfileFollowersListV2'
     return this._listFollows(url, offset)
   },
@@ -35,7 +35,7 @@ module.exports = {
    * @param {number} offset
    * @public
    */
-  followees(offset = 0) {
+  followees (offset = 0) {
     var url = '/node/ProfileFolloweesListV2'
     return this._listFollows(url, offset)
   },
@@ -45,11 +45,11 @@ module.exports = {
    *
    * @private
    */
-  _listFollows(url, offset) {
+  _listFollows (url, offset) {
     return Promise.all([
-        this._hash(),
-        this.xsrf()
-      ])
+      this._hash(),
+      this.xsrf()
+    ])
       .then(arr => {
         var data = {
           method: 'next',
@@ -71,7 +71,7 @@ module.exports = {
    * @param {number} [start] timestamp in second
    * @public
    */
-  activities(start) {
+  activities (start) {
     return this.xsrf()
       .then(_xsrf => {
         var url = `/people/${this._account.slug}/activities`
@@ -90,7 +90,7 @@ module.exports = {
    * @param {number} page
    * @public
    */
-  questions(page = 1) {
+  questions (page = 1) {
     var url = `/${this._type}/${this._account.slug}/asks`
     var params = {
       page
@@ -106,7 +106,7 @@ module.exports = {
    * @param {number} page
    * @public
    */
-  answers(page = 1) {
+  answers (page = 1) {
     var url = `/${this._type}/${this._account.slug}/answers`
     var params = {
       page
@@ -122,7 +122,7 @@ module.exports = {
    * @param {number} page
    * @public
    */
-  posts(page = 1) {
+  posts (page = 1) {
     var url = `/${this._type}/${this._account.slug}/posts`
     var params = {
       page
@@ -138,7 +138,7 @@ module.exports = {
    * @param {number} offset
    * @public
    */
-  topics(offset = 0) {
+  topics (offset = 0) {
     return this.xsrf()
       .then(_xsrf => {
         var url = `/people/${this._account.slug}/topics`
@@ -158,11 +158,11 @@ module.exports = {
    * @param {number} offset
    * @public
    */
-  columns(offset) {
+  columns (offset) {
     return Promise.all([
-        this._hash(),
-        this.xsrf()
-      ])
+      this._hash(),
+      this.xsrf()
+    ])
       .then(arr => {
         var url = '/node/ProfileFollowedColumnsListV2'
         var data = {
@@ -184,7 +184,7 @@ module.exports = {
    *
    * @private
    */
-  _hash() {
+  _hash () {
     var hash = this._account.hash
     if (hash) {
       return Promise.resolve(hash)

--- a/lib/api/answer.js
+++ b/lib/api/answer.js
@@ -9,7 +9,7 @@ module.exports = Answer
  * @param {number|object} aid
  * @public
  */
-function Answer(aid) {
+function Answer (aid) {
   if (!(this instanceof Answer)) {
     return new Answer(aid)
   }
@@ -29,7 +29,7 @@ function Answer(aid) {
  * @param {string} next a url string
  * @public
  */
-Answer.prototype.voters = function(next) {
+Answer.prototype.voters = function (next) {
   var url = next || `/answer/${this._answer.aid}/voters_profile`
 
   return this.get(url)
@@ -48,7 +48,7 @@ Answer.prototype.voters = function(next) {
  * @param {number} page
  * @public
  */
-Answer.prototype.comments = function(page = 1) {
+Answer.prototype.comments = function (page = 1) {
   var url = `/r/answers/${this._answer.aid}/comments`
   var params = {
     page
@@ -67,7 +67,7 @@ Answer.prototype.comments = function(page = 1) {
  * @param {number} offset
  * @public
  */
-Answer.exploreDay = function(offset = 0) {
+Answer.exploreDay = function (offset = 0) {
   return _explore(offset, 'day')
 }
 
@@ -79,11 +79,11 @@ Answer.exploreDay = function(offset = 0) {
  * @param {number} offset
  * @public
  */
-Answer.exploreMonth = function(offset = 0) {
+Answer.exploreMonth = function (offset = 0) {
   return _explore(offset, 'month')
 }
 
-function _explore(offset, type) {
+function _explore (offset, type) {
   var url = '/node/ExploreAnswerListV2'
   var params = {
     params: JSON.stringify({

--- a/lib/api/org.js
+++ b/lib/api/org.js
@@ -9,7 +9,7 @@ module.exports = Org
  * @param {string|object} uname
  * @public
  */
-function Org(slug) {
+function Org (slug) {
   if (!(this instanceof Org)) {
     return new Org(slug)
   }
@@ -31,7 +31,7 @@ Object.assign(Org.prototype, account)
  *
  * @public
  */
-Org.prototype.detail = function() {
+Org.prototype.detail = function () {
   var url = `/org/${this._account.slug}/about`
   return this.get(url)
     .then(parser.parseOrgDetail)

--- a/lib/api/question.js
+++ b/lib/api/question.js
@@ -8,7 +8,7 @@ module.exports = Question
  * @param {number|object} id
  * @public
  */
-function Question(id) {
+function Question (id) {
   if (!(this instanceof Question)) {
     return new Question(id)
   }
@@ -28,7 +28,7 @@ function Question(id) {
  * @param {number} offset
  * @public
  */
-Question.prototype.answersByVote = function(offset = 0) {
+Question.prototype.answersByVote = function (offset = 0) {
   return this.xsrf()
     .then(_xsrf => {
       var url = '/node/QuestionAnswerListV2'
@@ -52,7 +52,7 @@ Question.prototype.answersByVote = function(offset = 0) {
  * @param {number} page
  * @public
  */
-Question.prototype.answersByPage = function(page = 1) {
+Question.prototype.answersByPage = function (page = 1) {
   var url = `/question/${this._question.id}`
   var params = {
     page,
@@ -68,7 +68,7 @@ Question.prototype.answersByPage = function(page = 1) {
  *
  * @public
  */
-Question.prototype.detail = function() {
+Question.prototype.detail = function () {
   var url = `/question/${this._question.id}`
   return this.get(url)
     .then(parser.parseQuestionDetail)
@@ -80,7 +80,7 @@ Question.prototype.detail = function() {
  * @param {number} offset
  * @public
  */
-Question.prototype.followers = function(offset = 0) {
+Question.prototype.followers = function (offset = 0) {
   return this.xsrf()
     .then(_xsrf => {
       var url = `/question/${this._question.id}/followers`

--- a/lib/api/topic.js
+++ b/lib/api/topic.js
@@ -8,7 +8,7 @@ module.exports = Topic
  * @param {number|object} id
  * @public
  */
-function Topic(id) {
+function Topic (id) {
   if (!(this instanceof Topic)) {
     return new Topic(id)
   }
@@ -32,7 +32,7 @@ Topic.root = new Topic(19776749)
  *
  * @public
  */
-Topic.prototype.hierarchy = function() {
+Topic.prototype.hierarchy = function () {
   var url = `/topic/${this._topic.id}/organize`
   return this.get(url)
     .then(parser.parseTopicHierarchy)
@@ -45,7 +45,7 @@ Topic.prototype.hierarchy = function() {
  * @param {number} offset
  * @public
  */
-Topic.prototype.followers = function(start = '', offset = 0) {
+Topic.prototype.followers = function (start = '', offset = 0) {
   return this.xsrf()
     .then(_xsrf => {
       var url = `/topic/${this._topic.id}/followers`
@@ -65,7 +65,7 @@ Topic.prototype.followers = function(start = '', offset = 0) {
  * @param {number} page
  * @public
  */
-Topic.prototype.topAnswers = function(page = 1) {
+Topic.prototype.topAnswers = function (page = 1) {
   var url = `/topic/${this._topic.id}/top-answers`
   var params = {
     page
@@ -81,7 +81,7 @@ Topic.prototype.topAnswers = function(page = 1) {
  * @param {number} offset answer score
  * @public
  */
-Topic.prototype.hotAnswers = function(offset = '') {
+Topic.prototype.hotAnswers = function (offset = '') {
   return this.xsrf()
     .then(_xsrf => {
       var url = `/topic/${this._topic.id}/hot`
@@ -101,7 +101,7 @@ Topic.prototype.hotAnswers = function(offset = '') {
  * @param {number} offset answer score
  * @public
  */
-Topic.prototype.newAnswers = function(offset = '') {
+Topic.prototype.newAnswers = function (offset = '') {
   return this.xsrf()
     .then(_xsrf => {
       var url = `/topic/${this._topic.id}/newest`
@@ -124,7 +124,7 @@ Topic.prototype.newAnswers = function(offset = '') {
  * @param {number} page
  * @public
  */
-Topic.prototype.pendingQuestions = function(page = 1) {
+Topic.prototype.pendingQuestions = function (page = 1) {
   var url = `/topic/${this._topic.id}/questions`
   var params = {
     page
@@ -143,7 +143,7 @@ Topic.prototype.pendingQuestions = function(page = 1) {
  * @param {number} page
  * @public
  */
-Topic.prototype.hotPendingQuestions = function(page = 1) {
+Topic.prototype.hotPendingQuestions = function (page = 1) {
   var url = `/topic/${this._topic.id}/unanswered`
   var params = {
     page

--- a/lib/api/user.js
+++ b/lib/api/user.js
@@ -9,7 +9,7 @@ module.exports = User
  * @param {string|object} slug
  * @public
  */
-function User(slug) {
+function User (slug) {
   if (!(this instanceof User)) {
     return new User(slug)
   }
@@ -31,7 +31,7 @@ Object.assign(User.prototype, account)
  *
  * @public
  */
-User.prototype.detail = function() {
+User.prototype.detail = function () {
   var url = `/people/${this._account.slug}/about`
   return this.get(url)
     .then(parser.parseUserDetail)
@@ -43,7 +43,7 @@ User.prototype.detail = function() {
  * @param {number} page
  * @public
  */
-User.prototype.collections = function(page = 1) {
+User.prototype.collections = function (page = 1) {
   var url = `/people/${this._account.slug}/collections`
   var params = {
     page

--- a/lib/parser/account.js
+++ b/lib/parser/account.js
@@ -19,7 +19,7 @@ module.exports = {
   parseAccountColumns
 }
 
-function parseAccountProfile(html) {
+function parseAccountProfile (html) {
   var $ = cheerio.load(html)
   var upperEle = $('.upper')
   var lowerEle = $('.lower')
@@ -60,7 +60,7 @@ function parseAccountProfile(html) {
   return profile
 }
 
-function parseAccountFollows(htmls) {
+function parseAccountFollows (htmls) {
   var follows = htmls.map(html => {
     var $ = cheerio.load(html)
     var hashEle = $('.zm-rich-follow-btn')
@@ -80,14 +80,14 @@ function parseAccountFollows(htmls) {
   return follows
 }
 
-function parseAccountActivities(html) {
+function parseAccountActivities (html) {
   var $ = cheerio.load(html)
   var eles = $('.zm-profile-section-item')
 
   return util.map(eles, ele => _parseAccountActivity($, $(ele)))
 }
 
-function _parseAccountActivity($, ele) {
+function _parseAccountActivity ($, ele) {
   var time = getData(ele, 'time') * 1000
   var type = getData(ele, 'type-detail')
 
@@ -129,13 +129,13 @@ function _parseAccountActivity($, ele) {
 
   return activity
 
-  function getAnswer() {
+  function getAnswer () {
     var answer = _parseAccountAnswer($, ele)
     delete answer.crawltime
     return answer
   }
 
-  function getQuestion() {
+  function getQuestion () {
     var quesEle = $('.question_link', ele)
     var link = getAttr(quesEle, 'href')
     var title = getText(quesEle)
@@ -147,7 +147,7 @@ function _parseAccountActivity($, ele) {
     }
   }
 
-  function getTopic() {
+  function getTopic () {
     var topicEle = $('.topic-link', ele)
     var link = getAttr(topicEle, 'href')
     var name = getAttr(topicEle, 'title')
@@ -159,13 +159,13 @@ function _parseAccountActivity($, ele) {
     }
   }
 
-  function getPost() {
+  function getPost () {
     var post = _parseAccountPost($, ele)
     delete post.crawltime
     return post
   }
 
-  function getColumn() {
+  function getColumn () {
     var columnEle = $('.column_link', ele)
     var link = getAttr(columnEle, 'href')
     var name = getText(columnEle)
@@ -177,7 +177,7 @@ function _parseAccountActivity($, ele) {
     }
   }
 
-  function getCollection() {
+  function getCollection () {
     var collectionEle = $('a:last-child', ele)
     var link = getAttr(collectionEle, 'href')
     var name = getText(collectionEle)
@@ -189,7 +189,7 @@ function _parseAccountActivity($, ele) {
     }
   }
 
-  function getRoundTable() {
+  function getRoundTable () {
     var rtEle = $('.roundtable_link', ele)
     var link = getAttr(rtEle, 'href')
     var name = getText(rtEle)
@@ -202,14 +202,14 @@ function _parseAccountActivity($, ele) {
   }
 }
 
-function parseAccountQuestions(html) {
+function parseAccountQuestions (html) {
   var $ = cheerio.load(html)
   var eles = $('#zh-profile-ask-list .zm-profile-section-item')
 
   return util.map(eles, ele => _parseAccountQuestion($, $(ele)))
 }
 
-function _parseAccountQuestion($, ele) {
+function _parseAccountQuestion ($, ele) {
   var viewsEle = $('.zm-profile-vote-count .zm-profile-vote-num', ele)
   var questionEle = $('.zm-profile-section-main .question_link', ele)
   var link = getAttr(questionEle, 'href')
@@ -230,14 +230,14 @@ function _parseAccountQuestion($, ele) {
   return question
 }
 
-function parseAccountAnswers(html) {
+function parseAccountAnswers (html) {
   var $ = cheerio.load(html)
   var eles = $('#zh-profile-answer-list .zm-item')
 
   return util.map(eles, ele => _parseAccountAnswer($, $(ele)))
 }
 
-function _parseAccountAnswer($, ele) {
+function _parseAccountAnswer ($, ele) {
   var questionEle = $('.question_link', ele)
   var questionLink = getAttr(questionEle, 'href')
   questionLink = questionLink.substring(0, questionLink.indexOf('/answer'))
@@ -273,14 +273,14 @@ function _parseAccountAnswer($, ele) {
   return answer
 }
 
-function parseAccountPosts(html) {
+function parseAccountPosts (html) {
   var $ = cheerio.load(html)
   var eles = $('#zh-profile-post-list .zm-item')
 
   return util.map(eles, ele => _parseAccountPost($, $(ele)))
 }
 
-function _parseAccountPost($, ele) {
+function _parseAccountPost ($, ele) {
   var titleEle = $('.post-link', ele)
   var pidEle = $('meta[itemprop="post-id"]', ele)
   var idEle = $('meta[itemprop="post-url-token"]', ele)
@@ -302,14 +302,14 @@ function _parseAccountPost($, ele) {
   return post
 }
 
-function parseAccountTopics(html) {
+function parseAccountTopics (html) {
   var $ = cheerio.load(html)
   var eles = $('.zm-profile-section-item')
 
   return util.map(eles, ele => _parseAccountTopic($, $(ele)))
 }
 
-function _parseAccountTopic($, ele) {
+function _parseAccountTopic ($, ele) {
   var linkEle = $('.zm-list-avatar-link', ele)
   var avatarEle = $('.zm-list-avatar-medium', ele)
   var nameEle = $('.zm-profile-section-main strong', ele)
@@ -326,7 +326,7 @@ function _parseAccountTopic($, ele) {
   return topic
 }
 
-function parseAccountColumns(htmls) {
+function parseAccountColumns (htmls) {
   var columns = htmls.map(html => {
     var $ = cheerio.load(html)
     var linkEle = $('.zm-list-avatar-link')

--- a/lib/parser/answer.js
+++ b/lib/parser/answer.js
@@ -14,7 +14,7 @@ module.exports = {
   parseAnswerExplore
 }
 
-function parseAnswerVoters(htmls) {
+function parseAnswerVoters (htmls) {
   return util.map(htmls, html => {
     var $ = cheerio.load(html)
     var hashEle = $('.zm-rich-follow-btn')
@@ -32,7 +32,7 @@ function parseAnswerVoters(htmls) {
   })
 }
 
-function parseAnswerComments(obj) {
+function parseAnswerComments (obj) {
   var comments = obj.data.map(item => {
     var author = item.author
     var avatar = author.avatar
@@ -62,14 +62,14 @@ function parseAnswerComments(obj) {
   }
 }
 
-function parseAnswerExplore(html) {
+function parseAnswerExplore (html) {
   var $ = cheerio.load(html)
   var eles = $('.feed-item')
 
   return util.map(eles, ele => _parseExplore($, $(ele)))
 }
 
-function _parseExplore($, ele) {
+function _parseExplore ($, ele) {
   var quesEle = $('.question_link', ele)
   var quesLink = getAttr(quesEle, 'href')
   var link = quesLink

--- a/lib/parser/org.js
+++ b/lib/parser/org.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio')
-const urls = require('../urls')
 const util = require('./util')
 
 const getAttr = util.getAttr
@@ -8,7 +7,7 @@ const getData = util.getData
 const toNum = util.toNum
 const parseSlug = util.parseSlug
 
-exports.parseOrgDetail = function(html) {
+exports.parseOrgDetail = function (html) {
   var $ = cheerio.load(html)
   var profileMainEle = $('div.zm-profile-header-main')
   var profileInfoEle = $('div.zm-profile-header-info')

--- a/lib/parser/question.js
+++ b/lib/parser/question.js
@@ -16,7 +16,7 @@ module.exports = {
   parseQuestionFollowers
 }
 
-function parseQuestionAnswersByVote(htmls) {
+function parseQuestionAnswersByVote (htmls) {
   return util.map(htmls, html => {
     var $ = cheerio.load(html, {
       decodeEntities: false
@@ -26,7 +26,7 @@ function parseQuestionAnswersByVote(htmls) {
   })
 }
 
-function parseQuestionAnswersByPage(html) {
+function parseQuestionAnswersByPage (html) {
   var $ = cheerio.load(html, {
     decodeEntities: false
   })
@@ -35,7 +35,7 @@ function parseQuestionAnswersByPage(html) {
   return util.map(eles, ele => _parseQuestionAnswer($, $(ele)))
 }
 
-function _parseQuestionAnswer($, ele) {
+function _parseQuestionAnswer ($, ele) {
   var authorEle = $('.zm-item-answer-author-info .author-link', ele)
   var authorLink = getAttr(authorEle, 'href')
   var agreesEle = $('.zm-item-vote-info', ele)
@@ -62,7 +62,7 @@ function _parseQuestionAnswer($, ele) {
   return answer
 }
 
-function parseQuestionDetail(html) {
+function parseQuestionDetail (html) {
   var $ = cheerio.load(html)
   var mainEle = $('.zu-main-content-inner')
   var visitsEle = $('meta[itemprop="visitsCount"]', mainEle)
@@ -95,7 +95,7 @@ function parseQuestionDetail(html) {
 
   return question
 
-  function _parseQuestionTopic(ele) {
+  function _parseQuestionTopic (ele) {
     var link = getAttr(ele, 'href')
 
     return {
@@ -106,14 +106,14 @@ function parseQuestionDetail(html) {
   }
 }
 
-function parseQuestionFollowers(html) {
+function parseQuestionFollowers (html) {
   var $ = cheerio.load(html)
   var eles = $('.zm-profile-card')
 
   return util.map(eles, ele => _parseQuestionFollower($, $(ele)))
 }
 
-function _parseQuestionFollower($, ele) {
+function _parseQuestionFollower ($, ele) {
   var hashEle = $('.zm-rich-follow-btn', ele)
   var linkEle = $('.zm-item-link-avatar', ele)
   var link = getAttr(linkEle, 'href')

--- a/lib/parser/topic.js
+++ b/lib/parser/topic.js
@@ -15,7 +15,7 @@ module.exports = {
   parseTopicQuestions
 }
 
-function parseTopicHierarchy(html) {
+function parseTopicHierarchy (html) {
   var $ = cheerio.load(html)
   var linkEle = $('.topic-avatar .zm-entry-head-avatar-link')
   var link = getAttr(linkEle, 'href')
@@ -41,10 +41,10 @@ function parseTopicHierarchy(html) {
   return topic
 }
 
-function _parseHierarchyLabels($, eles) {
+function _parseHierarchyLabels ($, eles) {
   return util.map(eles, ele => parseLabel($, $(ele)))
 
-  function parseLabel($, ele) {
+  function parseLabel ($, ele) {
     var link = getAttr(ele, 'href').replace('/organize', '')
     var topic = {
       id: getData(ele, 'token'),
@@ -56,14 +56,14 @@ function _parseHierarchyLabels($, eles) {
   }
 }
 
-function parseTopicFollowers(html) {
+function parseTopicFollowers (html) {
   var $ = cheerio.load(html)
   var eles = $('.zm-person-item')
 
   return util.map(eles, ele => _parseTopicFollower($, $(ele)))
 }
 
-function _parseTopicFollower($, ele) {
+function _parseTopicFollower ($, ele) {
   var followEle = $('.zg-btn', ele)
   var avatarEle = $('.zm-list-avatar-medium img', ele)
   var nameEle = $('.zm-list-content-title a', ele)
@@ -79,14 +79,14 @@ function _parseTopicFollower($, ele) {
   return follower
 }
 
-function parseTopicAnswers(html) {
+function parseTopicAnswers (html) {
   var $ = cheerio.load(html)
   var eles = $('.feed-item')
 
   return util.map(eles, ele => _parseTopicAnswer($, $(ele)))
 }
 
-function _parseTopicAnswer($, ele) {
+function _parseTopicAnswer ($, ele) {
   var aidEle = $('meta[itemprop="answer-id"]')
   var quesEle = $('.question_link', ele)
   var quesLink = getAttr(quesEle, 'href')
@@ -123,14 +123,14 @@ function _parseTopicAnswer($, ele) {
   return answer
 }
 
-function parseTopicQuestions(html) {
+function parseTopicQuestions (html) {
   var $ = cheerio.load(html)
   var eles = $('.feed-item')
 
   return util.map(eles, ele => _parseTopicQuestion($, $(ele)))
 }
 
-function _parseTopicQuestion($, ele) {
+function _parseTopicQuestion ($, ele) {
   var linkEle = $('.question_link', ele)
   var link = getAttr(linkEle, 'href')
   var answersEle = $('meta[itemprop="answerCount"]', ele)

--- a/lib/parser/user.js
+++ b/lib/parser/user.js
@@ -13,7 +13,7 @@ module.exports = {
   parseUserCollections
 }
 
-function parseUserDetail(html) {
+function parseUserDetail (html) {
   var $ = cheerio.load(html)
   var profileMainEle = $('.zm-profile-header-main')
   var profileInfoEle = $('.zm-profile-header-info')
@@ -91,21 +91,22 @@ function parseUserDetail(html) {
   return profile
 }
 
-function parseUserActivities(html) {
-  var $ = cheerio.load(html)
-  var eles = $('.zm-profile-section-item')
+// To be implemented
+// function parseUserActivities (html) {
+//   var $ = cheerio.load(html)
+//   var eles = $('.zm-profile-section-item')
 
-  return util.map(eles, ele => _parseUserActivity($, $(ele)))
-}
+//   return util.map(eles, ele => _parseUserActivity($, $(ele)))
+// }
 
-function parseUserCollections(html) {
+function parseUserCollections (html) {
   var $ = cheerio.load(html)
   var eles = $('#zh-profile-fav-list .zm-profile-section-item')
 
   return util.map(eles, ele => _parseUserCollection($, $(ele)))
 }
 
-function _parseUserCollection($, ele) {
+function _parseUserCollection ($, ele) {
   var titleEle = $('.zm-profile-fav-item-title', ele)
   var metaEle = $('.zm-profile-fav-bio', ele)
   var followEle = $('.zg-btn-follow', ele)

--- a/lib/parser/util.js
+++ b/lib/parser/util.js
@@ -1,43 +1,43 @@
 const urls = require('../urls')
 
-function isFunction(fn) {
+function isFunction (fn) {
   return typeof fn === 'function'
 }
 
-exports.getAttr = function(ele, attr) {
+exports.getAttr = function (ele, attr) {
   return ele && isFunction(ele.attr) ? ele.attr(attr) || '' : ''
 }
 
-exports.getText = function(ele) {
+exports.getText = function (ele) {
   return ele && isFunction(ele.text) ? ele.text().trim() || '' : ''
 }
 
-exports.getData = function(ele, name) {
+exports.getData = function (ele, name) {
   var data = ele && isFunction(ele.data) ? ele.data(name) : ''
   return typeof data === 'number' ? data : (data || '')
 }
 
-exports.getHtml = function(ele) {
+exports.getHtml = function (ele) {
   return ele && isFunction(ele.html) ? ele.html() || '' : ''
 }
 
-exports.toNum = function(val) {
+exports.toNum = function (val) {
   if (!val) {
     return 0
   }
   val = parseInt(val, 10)
-  return val ? val : 0
+  return val || 0
 }
 
-exports.forEach = function(arr, fn) {
+exports.forEach = function (arr, fn) {
   return [].forEach.call(arr, fn)
 }
 
-exports.map = function(arr, fn) {
+exports.map = function (arr, fn) {
   return [].map.call(arr, fn)
 }
 
-exports.parseSlug = function(link) {
+exports.parseSlug = function (link) {
   var ret = {
     slug: '',
     type: '',

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,7 +8,7 @@ const debug = require('debug')('zhihu-api')
 
 module.exports = Request
 
-function Request() {
+function Request () {
   this.headers = {
     'User-Agent': userAgent,
     'Cookie': ''
@@ -22,7 +22,7 @@ function Request() {
  * @param {string|Buffer} cookie
  * @public
  */
-Request.prototype.setCookie = function(cookie) {
+Request.prototype.setCookie = function (cookie) {
   if (!cookie) {
     return
   }
@@ -37,25 +37,33 @@ Request.prototype.setCookie = function(cookie) {
 }
 
 /**
+ * Set proxy.
+ *
+ * @param {string} proxy
+ * @public
+ */
+Request.prototype.setProxy = function (proxy) {
+  this.proxy = proxy
+}
+
+/**
  * Send a GET request.
  *
  * @param  {string} url
  * @return {Promise}
  * @public
  */
-Request.prototype.get = function(url, params) {
+Request.prototype.get = function (url, params) {
   if (params) {
     url += '?' + querystring.stringify(params)
   }
-
   var opts = {
     url,
     method: 'GET',
     headers: this.headers
   }
-
+  if (this.proxy) opts['proxy'] = this.proxy
   debug('GET ', url)
-
   return this.request(opts)
 }
 
@@ -67,16 +75,15 @@ Request.prototype.get = function(url, params) {
  * @return {Promise}
  * @public
  */
-Request.prototype.post = function(url, data) {
+Request.prototype.post = function (url, data) {
   var opts = {
     url,
     method: 'POST',
     headers: this.headers,
     form: data
   }
-
+  if (this.proxy) opts['proxy'] = this.proxy
   debug('POST', url, data)
-
   return this.request(opts)
 }
 
@@ -87,7 +94,7 @@ Request.prototype.post = function(url, data) {
  * @return {Promise}
  * @public
  */
-Request.prototype.request = function(opts) {
+Request.prototype.request = function (opts) {
   if (opts.url.indexOf(baseurl) !== 0) {
     opts.url = baseurl + opts.url
   }
@@ -98,11 +105,11 @@ Request.prototype.request = function(opts) {
     })
   })
 
-  promise.json = function() {
+  promise.json = function () {
     return promise.then(JSON.parse)
   }
 
-  promise.$ = function() {
+  promise.$ = function () {
     return promise.then(cheerio.load)
   }
 
@@ -115,12 +122,12 @@ Request.prototype.request = function(opts) {
  * @return {Promise}
  * @public
  */
-Request.prototype.xsrf = function() {
+Request.prototype.xsrf = function () {
   if (this._xsrf) {
     return Promise.resolve(this._xsrf)
   }
 
   return this.get(baseurl)
     .$()
-    .then($ => this._xsrf = $('input[name="_xsrf"]').val())
+    .then(($) => { this._xsrf = $('input[name="_xsrf"]').val() })
 }

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -18,7 +18,7 @@ const baseurl = exports.baseurl = 'https://www.zhihu.com'
  * @return {string}
  * @public
  */
-exports.full = function(path) {
+exports.full = function (path) {
   if (!path) {
     return ''
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Unofficial API for zhihu (https://www.zhihu.com)",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/**/*.js",
+    "test": "standard && mocha test/**/*.js",
     "doc:clean": "rm -rf doc/_book",
     "doc:build": "npm run doc:clean && cd doc && gitbook build",
     "doc:publish": "npm run doc:build && cd doc/_book && git init && git commit --allow-empty -m \"Update doc\" && git checkout -b gh-pages && git add . && git commit -am \"Update docs\" && git push https://github.com/syaning/zhihu-api.git gh-pages --force"
@@ -40,7 +40,8 @@
     "chai": "^3.5.0",
     "gitbook-cli": "^2.3.0",
     "gitbook-plugin-highlight": "^2.0.2",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "standard": "^8.5.0"
   },
   "files": [
     "lib/",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+const api = require('./index')
+
+api.cookie(fs.readFileSync('./cookie'))
+api.user('zhihuadmin')
+    .detail()
+    .then(console.log)
+    .catch(console.trace)

--- a/test/api.js
+++ b/test/api.js
@@ -1,37 +1,38 @@
+/* eslint-env mocha */
 const api = require('..')
 const expect = require('chai').expect
 
-describe('api', function() {
-  it('#_request', function() {
+describe('api', function () {
+  it('#_request', function () {
     expect(api._request).to.be.an('object')
   })
 
-  it('#user', function() {
+  it('#user', function () {
     expect(api.user).to.be.a('function')
-    expect(api.user.prototype.__proto__).to.be.equal(api._request)
+    expect(Object.getPrototypeOf(api.user.prototype)).to.be.equal(api._request)
   })
 
-  it('#org', function() {
+  it('#org', function () {
     expect(api.org).to.be.a('function')
-    expect(api.org.prototype.__proto__).to.be.equal(api._request)
+    expect(Object.getPrototypeOf(api.org.prototype)).to.be.equal(api._request)
   })
 
-  it('#topic', function() {
+  it('#topic', function () {
     expect(api.topic).to.be.a('function')
-    expect(api.topic.prototype.__proto__).to.be.equal(api._request)
+    expect(Object.getPrototypeOf(api.topic.prototype)).to.be.equal(api._request)
   })
 
-  it('#question', function() {
+  it('#question', function () {
     expect(api.question).to.be.a('function')
-    expect(api.question.prototype.__proto__).to.be.equal(api._request)
+    expect(Object.getPrototypeOf(api.question.prototype)).to.be.equal(api._request)
   })
 
-  it('#answer', function() {
+  it('#answer', function () {
     expect(api.answer).to.be.a('function')
-    expect(api.answer.prototype.__proto__).to.be.equal(api._request)
+    expect(Object.getPrototypeOf(api.answer.prototype)).to.be.equal(api._request)
   })
 
-  it('#version', function() {
+  it('#version', function () {
     expect(api.version).to.be.a('string')
   })
 })

--- a/test/parser-util.js
+++ b/test/parser-util.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const expect = require('chai').expect
 const cheerio = require('cheerio')
 const util = require('../lib/parser/util')
@@ -9,29 +10,29 @@ var $ = cheerio.load(domstr, {
 })
 var ele = $('div')
 
-describe('parser util', function() {
-  it('#getAttr', function() {
+describe('parser util', function () {
+  it('#getAttr', function () {
     expect(util.getAttr(ele, 'id')).to.equal('example')
     expect(util.getAttr(ele, 'class')).to.equal('container')
   })
 
-  it('#getText', function() {
+  it('#getText', function () {
     expect(util.getText(ele)).to.equal('hello 世界')
   })
 
-  it('#getData', function() {
+  it('#getData', function () {
     expect(util.getData(ele, 'name')).to.equal('test')
     expect(util.getData(ele, 'id')).to.equal(123456)
     expect(util.getData(ele, 'count')).to.equal(0)
     expect(util.getData(ele, 'none')).to.equal('')
   })
 
-  it('#getHtml', function() {
+  it('#getHtml', function () {
     expect(util.getHtml($)).to.equal(domstr)
     expect(util.getHtml(ele)).to.equal('hello 世界')
   })
 
-  it('#toNum', function() {
+  it('#toNum', function () {
     expect(util.toNum(null)).to.equal(0)
     expect(util.toNum(undefined)).to.equal(0)
     expect(util.toNum([])).to.equal(0)
@@ -41,20 +42,20 @@ describe('parser util', function() {
     expect(util.toNum('12345')).to.equal(12345)
   })
 
-  it('#forEach', function() {
+  it('#forEach', function () {
     var arr = [1, 2, 3]
     var res = []
     util.forEach(arr, x => res.push(x * x))
     expect(res).to.eql([1, 4, 9])
   })
 
-  it('#map', function() {
+  it('#map', function () {
     var arr = [1, 2, 3]
     var res = util.map(arr, x => x * x)
     expect(res).to.eql([1, 4, 9])
   })
 
-  it('parseSlug', function() {
+  it('parseSlug', function () {
     var ret = util.parseSlug('/people/test')
     expect(ret.type).to.equal('people')
     expect(ret.slug).to.equal('test')

--- a/test/urls.js
+++ b/test/urls.js
@@ -1,12 +1,13 @@
+/* eslint-env mocha */
 const urls = require('../lib/urls')
 const expect = require('chai').expect
 
-describe('urls', function() {
-  it('#baseurl', function() {
+describe('urls', function () {
+  it('#baseurl', function () {
     expect(urls.baseurl).to.be.a('string')
   })
 
-  it('#full', function() {
+  it('#full', function () {
     var link = `${urls.baseurl}/people/test`
 
     expect(urls.full('')).to.equal('')


### PR DESCRIPTION
感谢开源`zhihu-api`

做了以下一些小改进:
- [x] 给request wraper加proxy支持, 对爬虫用户更友好 😁
- [x] 删除`.editorconfig`, 这个应该加到你本地的`.gitignore`里
- [x] 加入`standard` module, 强制检测代码风格
- [x] 给`README.md` 加上`standard.js` badge
- [x] 调整一些缩进空格

最近在做爬虫爬知乎, 你的包会给我省很多麻烦, 所以以后会重度使用😉

我现在想的有几点能改进地方: 
- 我个人比较喜欢ES6的`class`, `extend`等关键字
- 不是特别喜欢request在每个类的原型上
- 还有测试基本相当于没有...

有机会讨论一下, 我会持续贡献完善这个module的...

@syaning PTAL!